### PR TITLE
add in process Id to kill cmd for osx and linux

### DIFF
--- a/src/SpaCliMiddleware/Util/KillPort.cs
+++ b/src/SpaCliMiddleware/Util/KillPort.cs
@@ -175,12 +175,14 @@ namespace SpaCliMiddleware
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
                     if (force) { args.Add("-9"); }
-                    RunProcessReturnOutput("kill", "");
+                    args.Add(pid.ToString());
+                    RunProcessReturnOutput("kill", string.Join(" ", args));
                 }
                 else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
                     if (force) { args.Add("-9"); }
-                    RunProcessReturnOutput("kill", "");
+                    args.Add(pid.ToString());
+                    RunProcessReturnOutput("kill", string.Join(" ", args));
                 }
                 else
                 {


### PR DESCRIPTION
@Kiho The kill command doesn't actually specify the port to kill on osx or linux, and thus doesn't work.  This PR fixes that using the same method as the vue project you forked this from originally: https://github.com/EEParker/aspnetcore-vueclimiddleware/blob/master/src/VueCliMiddleware/Util/KillPort.cs#L178.